### PR TITLE
🐛 Prevent Termynal controls from scrolling

### DIFF
--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -133,7 +133,7 @@ class Termynal {
             this.container.innerHTML = ''
             this.init()
         }
-        restart.href = '#'
+        restart.href = 'javascript:void(0)'
         restart.setAttribute('data-terminal-control', '')
         restart.innerHTML = "restart ↻"
         return restart
@@ -147,7 +147,7 @@ class Termynal {
             this.typeDelay = 0
             this.startDelay = 0
         }
-        finish.href = '#'
+        finish.href = 'javascript:void(0)'
         finish.setAttribute('data-terminal-control', '')
         finish.innerHTML = "fast →"
         this.finishElement = finish


### PR DESCRIPTION
## Description

Prevent the Termynal `restart` and `fast` controls from navigating to the top of the documentation page when clicked.

This matches the fix already merged in fastapi/fastapi#13714 and proposed in fastapi/typer#1904.

## Checks

- `git diff --check`

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.
